### PR TITLE
Adding qfs module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+coverage.out
+godbpf.test

--- a/dbpf.go
+++ b/dbpf.go
@@ -2,12 +2,16 @@ package godbpf
 
 import (
     "io"
-    "bufio"
     "time"
-    "container/list"
-    "bytes"
     "encoding/binary"
     "errors"
+    "bytes"
+    "container/list"
+    "fmt"
+
+    "github.com/marcboudreau/godbpf/entry"
+    "github.com/marcboudreau/godbpf/qfs"
+    "github.com/marcboudreau/godbpf/util"
 )
 
 // DBPF is a structure that encompasses all of the contents of a DBPF file.
@@ -18,151 +22,233 @@ type DBPF struct {
   // The minor version of the DBPF schema used.
   MinorVersion uint32
 
+  // The major version of the index schema used in this DBPF instance.
+  IndexMajorVersion uint32
+
+  // The minor version of the index schema used in this DBPF instance.
+  IndexMinorVersion uint32
+
   // Timestamp of when this DBPF was created.
   CreatedDate time.Time
 
   // Timestamp of when this DBPF was last modified.
   ModifiedDate time.Time
 
-  // List of entries contained in this DBPF.
-  Entries *list.List
+  // entries points to a list of DBPFEntry (exluding the DBPFDirEntry) if one
+  // was created), contained in the DBPF instance.
+  entries *list.List
 }
 
-// New creates a new empty DBPF.
+// New creates a new DBPF instance.
 func New() *DBPF {
-  return &DBPF{MajorVersion: 7,
-               MinorVersion: 0,
-               CreatedDate: time.Now(),
-               ModifiedDate: time.Now(),
-               Entries: list.New()}
+  dbpf := new(DBPF)
+  dbpf.entries = list.New()
+
+  return dbpf
 }
 
-func littleEndianReadUint32(buf io.Reader, data *uint32) {
-  binary.Read(buf, binary.LittleEndian, data)
+// Len returns the number of entries in this DBPF instance.
+func (dbpf *DBPF) Len() uint32 {
+  return uint32(dbpf.entries.Len())
 }
 
 // Parse creates a DBPF from the data read from the provided reader.
-func Parse(reader io.Reader) (*DBPF, error) {
-  bufReader := bufio.NewReader(reader)
-  magic := make([]byte, 4)
-  if _, err := bufReader.Read(magic); err != nil {
-    return nil, err
+func Parse(r io.Reader) (*DBPF, error) {
+  dbpf := New()
+  count, offset, _ := parseHeader(r, dbpf)
+
+  contentBuf := make([]byte, offset)
+  if offset > 96 {
+    // Start reading in bytes at position 96 to account for the header data, that
+    // way all of the offset values read in the file will align in this slice as
+    // well.
+    if _, e := r.Read(contentBuf[96:]); e != nil {
+      return nil, e
+    }
   }
 
-  if magic[0] != 'D' && magic[1] != 'B' && magic[2] != 'P' && magic[3] != 'F' {
-    return nil, errors.New("Invalid magic number")
-  }
-
-  var majorVersion uint32
-  var minorVersion uint32
-
-  littleEndianReadUint32(bufReader, &majorVersion)
-  littleEndianReadUint32(bufReader, &minorVersion)
-
-  bufReader.Discard(12)
-
-  var createdDate uint32
-  var modifiedDate uint32
-
-  littleEndianReadUint32(bufReader, &createdDate)
-  littleEndianReadUint32(bufReader, &modifiedDate)
-
-  dbpf := &DBPF{majorVersion, minorVersion, time.Unix(int64(createdDate), 0), time.Unix(int64(modifiedDate), 0), list.New()}
+  dbpf.parseEntries(r, offset, count, contentBuf)
 
   return dbpf, nil
 }
 
-func littleEndianWrite(buf io.Writer, value interface{}) {
-  binary.Write(buf, binary.LittleEndian, value)
+// parseHeader parses the header section of the DBPF file and populates the values
+// in the provided DBPF instance.
+func parseHeader(r io.Reader, dbpf *DBPF) (count, offset uint32, e error) {
+  fmt.Println("ENTER parseHeader")
+  defer fmt.Println("EXIT parseHeader")
+
+  magic := make([]byte, 4)
+  if _, e := r.Read(magic); e != nil {
+    return 0, 0, e
+  }
+
+  if string(magic) != "DBPF" {
+    return 0, 0, errors.New("Invalid magic number")
+  }
+
+  binary.Read(r, binary.LittleEndian, &dbpf.MajorVersion)
+  binary.Read(r, binary.LittleEndian, &dbpf.MinorVersion)
+
+  fmt.Printf("  dbpf.MajorVersion = %d\n", dbpf.MajorVersion)
+  fmt.Printf("  dbpf.MinorVersion = %d\n", dbpf.MinorVersion)
+
+  r.Read(make([]byte, 12))
+
+  var timestamp uint32
+  binary.Read(r, binary.LittleEndian, &timestamp)
+  dbpf.CreatedDate = time.Unix(int64(timestamp), 0)
+  binary.Read(r, binary.LittleEndian, &timestamp)
+  dbpf.ModifiedDate = time.Unix(int64(timestamp), 0)
+
+  fmt.Printf("  dbpf.CreatedDate = 0x%08X\n", dbpf.CreatedDate.Unix())
+  fmt.Printf("  dbpf.ModifiedDate = 0x%08X\n", dbpf.ModifiedDate.Unix())
+
+  binary.Read(r, binary.LittleEndian, &dbpf.IndexMajorVersion)
+  binary.Read(r, binary.LittleEndian, &count)
+  binary.Read(r, binary.LittleEndian, &offset)
+
+  fmt.Printf("  index.MajorVersion = %d\n", dbpf.IndexMajorVersion)
+  fmt.Printf("  count = %d\n", count)
+  fmt.Printf("  offset = %d\n", offset)
+
+  // Gobble up the index size and 3 other  unused uint32 values
+  r.Read(make([]byte, 16))
+
+  binary.Read(r, binary.LittleEndian, &dbpf.IndexMinorVersion)
+
+  fmt.Printf("  index.MinorVersion = %d\n", dbpf.IndexMinorVersion)
+
+  // Gobble up 10 unused uint32 values
+  r.Read(make([]byte, 40))
+
+  return count, offset, nil
 }
 
-func (dbpf *DBPF) Save(writer io.Writer) error {
-  buf := bytes.NewBuffer(make([]byte, 28))
-  buf.WriteString("DBPF")
-  littleEndianWrite(buf, dbpf.MajorVersion)
-  littleEndianWrite(buf, dbpf.MinorVersion)
-  littleEndianWrite(buf, []uint32{0, 0, 0})
-  littleEndianWrite(buf, uint32(dbpf.CreatedDate.Unix()))
-  littleEndianWrite(buf, uint32(dbpf.ModifiedDate.Unix()))
-  // littleEndianWrite(buf, uint32(7))
-  // littleEndianWrite(buf, uint32(dbpf.Entries.Len()))
-  //
-  // contentBuf := dbpf.encodeContent()
-  //
-  // littleEndianWrite(buf, uint32(contentBuf.Len() + 96))
-  // littleEndianWrite(buf, uint32(20 * (dbpf.Entries.Len() + 1)))
-  //
-  // var filler [48]byte
-  // buf.Write(filler)
-  //
-  // // Write the file entries
-  // buf.Write(contentBuf.Bytes())
-  //
-  // // Write the index table
-  // buf.Write(encodeIndex().Bytes())
+func (dbpf *DBPF) parseEntries(r io.Reader, indexOffset, indexCount uint32, content []byte) {
+  for i := 0; i < int(indexCount); i++ {
+    var typeId, groupId, instanceId, location, size uint32
 
-  writer.Write(buf.Bytes())
+    binary.Read(r, binary.LittleEndian, &typeId)
+    binary.Read(r, binary.LittleEndian, &groupId)
+    binary.Read(r, binary.LittleEndian, &instanceId)
+    binary.Read(r, binary.LittleEndian, &location)
+    binary.Read(r, binary.LittleEndian, &size)
+
+    entry := &entry.DBPFEntry{TGI: &entry.DBPFEntryTGI{TypeId: typeId, GroupId: groupId, InstanceId: instanceId}}
+    entry.SetData(content[location:location + size])
+
+    dbpf.entries.PushBack(entry)
+  }
+}
+
+func (dbpf *DBPF) Save(w io.Writer) error {
+  w.Write([]byte("DBPF"))
+
+  binary.Write(w, binary.LittleEndian, dbpf.MajorVersion)
+  binary.Write(w, binary.LittleEndian, dbpf.MinorVersion)
+
+  w.Write(make([]byte, 12))
+
+  binary.Write(w, binary.LittleEndian, uint32(dbpf.CreatedDate.Unix()))
+  binary.Write(w, binary.LittleEndian, uint32(dbpf.ModifiedDate.Unix()))
+
+  binary.Write(w, binary.LittleEndian, dbpf.IndexMajorVersion)
+  binary.Write(w, binary.LittleEndian, dbpf.Len())
+
+  contentBuf := dbpf.encodeContent()
+
+  binary.Write(w, binary.LittleEndian, uint32(contentBuf.Len() + 96))
+  binary.Write(w, binary.LittleEndian, uint32(20 * dbpf.Len()))
+
+  w.Write(make([]byte, 48))
+
+  // Write the file entries
+  contentBuf.WriteTo(w)
+
+  // // Write the index table
+  dbpf.encodeIndex(w)
 
   return nil
 }
 
-// func (dbpf *DBPF) encodeContent() *bytes.Buffer {
-//   buf := new(bytes.Buffer)
-//
-//   return buf
-// }
+func (dbpf *DBPF) encodeContent() *bytes.Buffer {
+  buf := new(bytes.Buffer)
 
-// func (dbpf *DBPF) encodeIndex() *bytes.Buffer {
-//   buf := new(bytes.Buffer)
-//
-//   for elem := dbpf.Entries.Front(); elem.Next() != nil; elem = elem.Next() {
-//     dbpfEntry := elem.Value
-//
-//     littleEndianWrite(buf, dbpfEntry.TypeId)
-//     littleEndianWrite(buf, dbpfEntry.GroupId)
-//     littleEndianWrite(buf, dbpfEntry.InstanceId)
-//     littleEndianWrite(buf, dbpfEntry.Location)
-//     littleEndianWrite(buf, uint32(dbpfEntry.Data.Len()))
-//   }
-//
-//   return buf
-// }
+  for elem := dbpf.entries.Front(); elem != nil; elem = elem.Next() {
+    if entry, ok := elem.Value.(*entry.DBPFEntry); ok {
+      buf.Write(entry.GetData())
+    }
+  }
 
+  return buf
+}
 
-// EncodeIndexHeader encodes the receiver *DBPFIndex object into its binary form
-//  and writes the data into a slice of bytes that's returned.
-// func (index *DBPFIndex) EncodeIndexHeader() []byte, error {
-//   buf := bytes.Buffer
-//   binary.Write(buf, binary.LittleEndian, index.MajorVersion)
-//   binary.Write(buf, binary.LittleEndian, index.MinorVersion)
-//   binary.Write(buf, binary.LittleEndian, uint32(index.Entries.Len()))
-//
-//
-//
-//   return data
-// }
+// encodeIndex encodes the index entries and writes the binary data to the
+// provided io.Writer.
+func (dbpf *DBPF) encodeIndex(w io.Writer) {
+  location := uint32(96)
+  for elem := dbpf.entries.Front(); elem != nil; elem = elem.Next() {
+    if entry, ok := elem.Value.(*entry.DBPFEntry); ok {
+      binary.Write(w, binary.LittleEndian, entry.TGI.TypeId)
+      binary.Write(w, binary.LittleEndian, entry.TGI.GroupId)
+      binary.Write(w, binary.LittleEndian, entry.TGI.InstanceId)
+      binary.Write(w, binary.LittleEndian, location)
+      binary.Write(w, binary.LittleEndian, entry.Size())
 
-// func (dbpf *DBPF) Encode() []byte, error {
-//   buf := bytes.Buffer
-//   buf.WriteString("DBPF")
-//   binary.Write(buf, binary.LittleEndian, dbpf.MajorVersion)
-//   binary.Write(buf, binary.LittleEndian, dbpf.MinorVersion)
-//   binary.Write(buf, binary.LittleEndian, []uint32{0, 0, 0})
-//   binary.Write(buf, binary.LittleEndian, uint32(dbpf.createdDate.Unix()))
-//   binary.Write(buf, binary.LittleEndian, uint32(dbpf.modifiedDate.Unix()))
-//   binary.Write(buf, binary.LittleEndian, dbpf.index.MajorVersion)
-//   binary.Write(buf, binary.LittleEndian, uint32(dbpf.index.Entries.Len()))
-//
-//
-//
-//   binary.Write(buf, binary.LittleEndian, dbpf.index.MinorVersion)
-//
-// }
+      location += entry.Size()
+    }
+  }
+}
 
-// type DBPFEntry struct {
-//   TypeId uint32
-//   GroupId uint32
-//   InstanceId uint32
-//   Location uint32
-//   Data *bytes.Buffer
-// }
+// AddEntry adds the provided DBPFEntry instance to the DBPF instance and creates
+// an entry in the DBPFIndex instance as well.
+func (dbpf *DBPF) AddEntry(e *entry.DBPFEntry) {
+  dbpf.entries.PushBack(e)
+}
+
+func (dbpf *DBPF) AddCompressedEntry(tgi *entry.DBPFEntryTGI, uncompressedData []byte) {
+  entry := &entry.DBPFEntry{TGI: tgi}
+  buf := new(bytes.Buffer)
+  qfs.Encode(buf, uncompressedData)
+
+  data := make([]byte, 4 + buf.Len())
+  copy(data[0:4], util.WriteUint32(uint32(buf.Len())))
+  copy(data[4:], buf.Bytes())
+  entry.SetData(data)
+
+  dbpf.entries.PushBack(entry)
+
+  dirEntry := dbpf.GetDirEntry()
+  dirEntry.AddEntry(tgi, uint32(len(uncompressedData)))
+}
+
+// GetDirEntry locates and returns the DIR entry in the receiver.  If there isn't
+// one, then one is created.
+func (dbpf *DBPF) GetDirEntry() *entry.DBPFEntry {
+  dirEntry := dbpf.Find(entry.DIR_ENTRY_TGI)
+  if dirEntry == nil {
+    dirEntry = entry.CreateDirEntry()
+    dbpf.AddEntry(dirEntry)
+  }
+
+  return dirEntry
+}
+
+// Find searches the index and returns the related DBPFEntry instance.
+func (dbpf *DBPF) Find(tgi *entry.DBPFEntryTGI) *entry.DBPFEntry {
+  fmt.Printf("ENTER Find(tgi: %s)\n", tgi.String())
+  defer fmt.Println("EXIT Find")
+
+  for elem := dbpf.entries.Front(); elem != nil; elem = elem.Next() {
+    if entry, ok := elem.Value.(*entry.DBPFEntry); ok {
+      fmt.Printf("  entry: %s\n", entry.String())
+      if entry.TGI.Equals(tgi) {
+        fmt.Println("  found the match")
+        return entry
+      }
+    }
+  }
+
+  return nil
+}

--- a/dbpf_test.go
+++ b/dbpf_test.go
@@ -4,13 +4,16 @@ import (
   "testing"
   "time"
   "bytes"
+  "fmt"
+
+  "github.com/marcboudreau/godbpf/entry"
 )
 
 func TestSchemaVersionOnNewDBPF(t *testing.T) {
-  dbpf := New()
+  dbpf := &DBPF{MajorVersion: 1, MinorVersion: 0}
 
   // Make sure the schema version is set to 7.0
-  if dbpf.MajorVersion != 7 {
+  if dbpf.MajorVersion != 1 {
     t.Error()
   }
 
@@ -19,52 +22,59 @@ func TestSchemaVersionOnNewDBPF(t *testing.T) {
   }
 }
 
-func TestCreatedDateOnNewDBPF(t *testing.T) {
-  dbpf := New()
-
-  // Make sure the created time is within a second from now.
+func TestCreatedAndModifiedDateOnNewDBPF(t *testing.T) {
+  dbpf := &DBPF{CreatedDate: time.Now(), ModifiedDate: time.Now()}
   now := time.Now().Unix()
   created := dbpf.CreatedDate.Unix()
+  modified := dbpf.ModifiedDate.Unix()
 
+  // The created date should no more than 1 second earlier than now
   if now - created > 1 {
     t.Error()
   }
-}
 
-func TestModifiedDateOnNewDBPF(t *testing.T) {
-  dbpf := New()
-
-  // Make sure the modified time is within a second from now.
-  now := time.Now().Unix()
-  modified := dbpf.ModifiedDate.Unix()
-
+  // The modified date should no more than 1 second earlier than now
   if now - modified > 1 {
     t.Error()
   }
 }
 
-func TestEntryListEmptyOnNewDBPF(t *testing.T) {
+func TestLenOnNewDBPF(t *testing.T) {
   dbpf := New()
 
-  // Make sure the Entries list is not nil but is empty.
-  if dbpf.Entries == nil {
-    t.Error()
-  }
-
-  if dbpf.Entries.Len() != 0 {
+  // Make sure the index is empty
+  if dbpf.Len() != 0 {
     t.Error()
   }
 }
 
 func TestParseDBPF(t *testing.T) {
   data := []byte{'D', 'B', 'P', 'F',
-                 7, 0, 0, 0,
+                 1, 0, 0, 0,
                  0, 0, 0, 0,
                  0, 0, 0, 0,
                  0, 0, 0, 0,
                  0, 0, 0, 0,
                  224, 125, 223, 86,
-                 224, 125, 223, 86 }
+                 224, 125, 223, 86,
+                 7, 0, 0, 0,
+                 0, 0, 0, 0,
+                 96, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0 }
   buf := bytes.NewBuffer(data)
 
   dbpf, err := Parse(buf)
@@ -72,7 +82,7 @@ func TestParseDBPF(t *testing.T) {
     t.Error()
   }
 
-  if dbpf.MajorVersion != 7 {
+  if dbpf.MajorVersion != 1 {
     t.Error()
   }
 
@@ -83,13 +93,32 @@ func TestParseDBPF(t *testing.T) {
 
 func TestParseDBPFWithDifferentModifiedDate(t *testing.T) {
   data := []byte{'D', 'B', 'P', 'F',
-                 7, 0, 0, 0,
+                 1, 0, 0, 0,
                  0, 0, 0, 0,
                  0, 0, 0, 0,
                  0, 0, 0, 0,
                  0, 0, 0, 0,
                  224, 125, 223, 86,
-                 102, 139, 223, 86 }
+                 102, 139, 223, 86,
+                 7, 0, 0, 0,
+                 0, 0, 0, 0,
+                 96, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0,
+                 0, 0, 0, 0 }
+
   buf := bytes.NewBuffer(data)
 
   dbpf, err := Parse(buf)
@@ -97,11 +126,205 @@ func TestParseDBPFWithDifferentModifiedDate(t *testing.T) {
     t.Error()
   }
 
-  if dbpf.MajorVersion != 7 {
+  if dbpf.MajorVersion != 1 {
     t.Error()
   }
 
   if dbpf.MinorVersion != 0 {
     t.Error()
+  }
+}
+
+// func TestCreateNewDBPFWithAnEntry(t *testing.T) {
+//   dbpf := New()
+//   data := []byte{ 0xA5, 0x5A, 0xA5, 0x5A,
+//                   0xA5, 0x5A, 0xA5, 0x5A,
+//                   0xA5, 0x5A, 0xA5, 0x5A,
+//                   0xA5, 0x5A, 0xA5, 0x5A,
+//                   0xA5, 0x5A, 0xA5, 0x5A }
+//
+//   tgi := &entry.DBPFEntryTGI{ TypeId: 0x7ab50e44, GroupId: 0x0986135e, InstanceId: 0xffff4000 }
+//   entry := &entry.DBPFEntry{ TGI: tgi }
+//   entry.SetData(data)
+//
+//   dbpf.Entries.PushBack(entry)
+//
+//   if dbpf.Index.Len() != 1 {
+//     t.Error()
+//   }
+// }
+
+func TestFindEntryUsingTGI(t *testing.T) {
+  dbpf := New()
+  data1 := []byte{ 0xAA, 0xAA, 0xAA, 0xAA,
+                  0xAA, 0xAA, 0xAA, 0xAA,
+                  0xAA, 0xAA, 0xAA, 0xAA,
+                  0xAA, 0xAA, 0xAA, 0xAA,
+                  0xAA, 0xAA, 0xAA, 0xAA }
+
+  data2 := []byte{ 0x55, 0x55, 0x55, 0x55,
+                  0x55, 0x55, 0x55, 0x55,
+                  0x55, 0x55, 0x55, 0x55,
+                  0x55, 0x55, 0x55, 0x55,
+                  0x55, 0x55, 0x55, 0x55 }
+
+  tgi1 := &entry.DBPFEntryTGI{ TypeId: 0x7ab50e44, GroupId: 0x0986135e, InstanceId: 0xffff4000 }
+  tgi2 := &entry.DBPFEntryTGI{ TypeId: 0x7ab50e44, GroupId: 0x0986135e, InstanceId: 0xffff4005 }
+
+  entry1 := entry.NewEntry(tgi1)
+  entry2 := entry.NewEntry(tgi2)
+  entry1.SetData(data1)
+  entry2.SetData(data2)
+
+  dbpf.AddEntry(entry1)
+  dbpf.AddEntry(entry2)
+
+  if entry := dbpf.Find(tgi1); entry.GetData()[0] != byte(0xAA) {
+    t.Error()
+  }
+
+  if entry := dbpf.Find(tgi2); entry.GetData()[0] != byte(0x55) {
+    t.Error()
+  }
+}
+
+func TestFindIndexEntries(t *testing.T) {
+  dbpf := New()
+
+  data1 := []byte{ 0xAA, 0xAA, 0xAA, 0xAA,
+                  0xAA, 0xAA, 0xAA, 0xAA,
+                  0xAA, 0xAA, 0xAA, 0xAA,
+                  0xAA, 0xAA, 0xAA, 0xAA,
+                  0xAA, 0xAA, 0xAA, 0xAA }
+
+  data2 := []byte{ 0x55, 0x55, 0x55, 0x55,
+                  0x55, 0x55, 0x55, 0x55,
+                  0x55, 0x55, 0x55, 0x55,
+                  0x55, 0x55, 0x55, 0x55,
+                  0x55, 0x55, 0x55, 0x55 }
+
+  tgi1 := &entry.DBPFEntryTGI{ TypeId: 0x7ab50e44, GroupId: 0x0986135e, InstanceId: 0xffff4000 }
+  tgi2 := &entry.DBPFEntryTGI{ TypeId: 0x7ab50e44, GroupId: 0x0986135e, InstanceId: 0xffff4005 }
+
+  entry1 := entry.NewEntry(tgi1)
+  entry2 := entry.NewEntry(tgi2)
+
+  entry1.SetData(data1)
+  entry2.SetData(data2)
+
+  dbpf.AddEntry(entry1)
+  dbpf.AddEntry(entry2)
+
+  if dbpf.Len() != 2 {
+    t.Error()
+  }
+
+  if entry := dbpf.Find(tgi1); !entry.TGI.Equals(tgi1) {
+    t.Error()
+  }
+
+  if entry := dbpf.Find(tgi2); !entry.TGI.Equals(tgi2) {
+    t.Error()
+  }
+}
+
+func TestSaveEmptyDBPF(t *testing.T) {
+  dbpf := New()
+  dbpf.MajorVersion = 1
+  dbpf.MinorVersion = 0
+  dbpf.CreatedDate = time.Unix(3465168386, 0)
+  dbpf.ModifiedDate = time.Unix(3751499539, 0)
+  dbpf.IndexMajorVersion = 7
+  dbpf.IndexMinorVersion = 0
+  byteBuffer := []byte{}
+  buffer := bytes.NewBuffer(byteBuffer)
+  expected := []byte{ 'D', 'B', 'P', 'F',
+                      0x1, 0x0, 0x0, 0x0,
+                      0x0, 0x0, 0x0, 0x0,
+                      0x0, 0x0, 0x0, 0x0,
+                      0x0, 0x0, 0x0, 0x0,
+                      0x0, 0x0, 0x0, 0x0,
+                      0x02, 0x46, 0x8A, 0xCE,
+                      0x13, 0x57, 0x9B, 0xDF,
+                      0x7, 0x0, 0x0, 0x0,
+                      0x0, 0x0, 0x0, 0x0 }
+
+  dbpf.Save(buffer)
+
+  for i := 0; i < 40; i++ {
+    if c, _ := buffer.ReadByte(); c != expected[i] {
+      t.Error(fmt.Sprintf("Assertion failed. Byte %d expecting %2x but was %2x\n", i, expected[i], c))
+    }
+  }
+}
+
+func TestSaveSingleEntryDBPF(t *testing.T) {
+  dbpf := New()
+  dbpf.MajorVersion = 1
+  dbpf.MinorVersion = 0
+  dbpf.CreatedDate = time.Unix(3465168386, 0)
+  dbpf.ModifiedDate = time.Unix(3751499539, 0)
+  dbpf.IndexMajorVersion = 7
+  dbpf.IndexMinorVersion = 0
+  byteBuffer := []byte{}
+  buffer := bytes.NewBuffer(byteBuffer)
+  expected := []byte{ 'D', 'B', 'P', 'F',
+                       0x1, 0x0, 0x0, 0x0, // Major version
+                       0x0, 0x0, 0x0, 0x0, // Minor version
+                       0x0, 0x0, 0x0, 0x0,
+                       0x0, 0x0, 0x0, 0x0,
+                       0x0, 0x0, 0x0, 0x0,
+                       0x02, 0x46, 0x8A, 0xCE, // Created date
+                       0x13, 0x57, 0x9B, 0xDF, // Modified date
+                       0x7, 0x0, 0x0, 0x0, // Index major version
+                       0x2, 0x0, 0x0, 0x0, // Index entry count
+                       0x7E, 0x0, 0x0, 0x0, // Offset of first index entry
+                       0x28, 0x0, 0x0, 0x0, // Size of the index
+                       0x0, 0x0, 0x0, 0x0, // Hole entry count
+                       0x0, 0x0, 0x0, 0x0, // Hole offset
+                       0x0, 0x0, 0x0, 0x0, // Hole size
+                       0x0, 0x0, 0x0, 0x0, // Index minor version
+                       0x0, 0x0, 0x0, 0x0, // Index offset
+                       0x0, 0x0, 0x0, 0x0,
+                       0x0, 0x0, 0x0, 0x0,
+                       0x0, 0x0, 0x0, 0x0,
+                       0x0, 0x0, 0x0, 0x0,
+                       0x0, 0x0, 0x0, 0x0,
+                       0x0, 0x0, 0x0, 0x0,
+                       0x0, 0x0, 0x0, 0x0,
+                       // First file
+                       0xA, 0x0, 0x0, 0x0, // Compressed size
+                       0x10, 0xFB, // Compression ID
+                       0x0, 0x0, 0x14, // Uncompressed size
+                       0x8F, 0x40, 0x0, 0xAA, // Compressed data
+                       0xFC,
+                       // DIR file
+                       0x44, 0xE, 0xB5, 0x7A, // TypeId
+                       0x5E, 0x13, 0x86, 0x9, // GroupId
+                       0x0, 0x40, 0xFF, 0xFF, // InstanceId
+                       0x14, 0x0, 0x0, 0x0, // Uncompressed size
+                       // Index
+                       //  First entry
+                       0x44, 0xE, 0xB5, 0x7A, // TypeId
+                       0x5E, 0x13, 0x86, 0x9, // GroupId
+                       0x0, 0x40, 0xFF, 0xFF, // InstanceId
+                       0x60, 0x0, 0x0, 0x0, // Location in file
+                       0xE, 0x0, 0x0, 0x0, // Size
+                       //  Dir entry
+                       0xEF, 0x1E, 0x6B, 0xE8, // TypeId
+                       0xEF, 0x1E, 0x6B, 0xE8, // GroupId
+                       0x3, 0x1F, 0x6B, 0x28, // InstanceId
+                       0x6E, 0x0, 0x0, 0x0, // Location in file
+                       0x10, 0x0, 0x0, 0x0 } // Size
+
+  tgi := &entry.DBPFEntryTGI{ TypeId: 0x7ab50e44, GroupId: 0x0986135e, InstanceId: 0xffff4000 }
+  dbpf.AddCompressedEntry(tgi, []byte{ 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA })
+
+  dbpf.Save(buffer)
+
+  for i := 0; i < len(expected); i++ {
+    if c, _ := buffer.ReadByte(); c != expected[i] {
+      t.Error(fmt.Sprintf("Assertion failed. Byte %d expecting %2x but was %2x\n", i, expected[i], c))
+    }
   }
 }

--- a/entry/dbpfdirentry.go
+++ b/entry/dbpfdirentry.go
@@ -1,0 +1,38 @@
+package entry
+
+import (
+  "fmt"
+
+  "github.com/marcboudreau/godbpf/util"
+)
+
+var DIR_ENTRY_TGI *DBPFEntryTGI = &DBPFEntryTGI{TypeId: 0xE86B1EEF, GroupId: 0xE86B1EEF, InstanceId: 0x286B1F03}
+
+// AddEntry modifies the receiver DBPFEntry to include the provided DBPFEntryTGI
+// and size.  The method will make sure that the receiver DBPFEntry instance has
+// the correct DBPFEntryTGI value, otherwise it will panic.
+func (e *DBPFEntry) AddEntry(tgi *DBPFEntryTGI, size uint32) {
+  if !e.TGI.Equals(DIR_ENTRY_TGI) {
+    panic(fmt.Sprintf("dbpfdirentry.AddEntry() can only be called with a DBPFEntry that has this TGI: {%s}\n", DIR_ENTRY_TGI))
+  }
+
+  entryData := make([]byte, 16)
+  tgi.Bytes(entryData[0:12])
+  copy(entryData[12:], util.WriteUint32(size))
+
+  data := e.GetData()
+  pos := 0
+  if data == nil {
+    data = make([]byte, 16)
+  } else {
+    pos = len(data)
+    data = make([]byte, pos + 16)
+  }
+
+  copy(data[pos:], entryData)
+  e.SetData(data)
+}
+
+func CreateDirEntry() *DBPFEntry {
+  return &DBPFEntry{TGI: DIR_ENTRY_TGI}
+}

--- a/entry/dbpfentry.go
+++ b/entry/dbpfentry.go
@@ -1,0 +1,63 @@
+package entry
+
+import (
+  "bytes"
+  "fmt"
+
+  "github.com/marcboudreau/godbpf/qfs"
+)
+
+
+// The DBPFEntry struct defines three methods common to all entries within a
+// DBPF file.
+type DBPFEntry struct {
+  // The TGI field is a pointer to a DBPFEntryTGI struct, which encapsulates a
+  // TypeId, a GroupId, and an InstanceId value.
+  TGI *DBPFEntryTGI
+
+  // The Data method returns the bytes that the make up the entry.
+  data []byte
+}
+
+// NewEntry creates a new empty entry with the provided DBPFEntryTGI instance.
+func NewEntry(tgi *DBPFEntryTGI) *DBPFEntry {
+  return &DBPFEntry{ TGI: tgi, data: nil }
+}
+
+// Size returns the size of the data stored in this entry.
+func (e *DBPFEntry) Size() uint32 {
+  return uint32(len(e.data))
+}
+
+// SetData updates the data stored in this entry, without performing any kind
+// of encoding.
+func (e *DBPFEntry) SetData(data []byte) {
+  e.data = make([]byte, len(data))
+  copy(e.data, data)
+}
+
+// GetData retrieves the data stored in this entry as is, without doing any
+// decoding.
+func (e *DBPFEntry) GetData() []byte {
+  return e.data
+}
+
+// ReadData decodes the data stored in this entry, if that's necessary (e.g. QFS
+// compressed data).
+func (e *DBPFEntry) ReadData() ([]byte, error) {
+  buffer := bytes.NewBuffer(e.data)
+
+  return qfs.Decode(buffer)
+}
+
+func (e *DBPFEntry) WriteData(data []byte) {
+  buffer := new(bytes.Buffer)
+
+  qfs.Encode(buffer, data)
+  e.data = buffer.Bytes()
+}
+
+// String returns a string representation of the receiver.
+func (e *DBPFEntry) String() string {
+  return fmt.Sprintf("TGI: %v, data: %v\n", e.TGI, e.data)
+}

--- a/entry/dbpfentrytgi.go
+++ b/entry/dbpfentrytgi.go
@@ -1,0 +1,47 @@
+package entry
+
+import (
+  "fmt"
+
+  "github.com/marcboudreau/godbpf/util"
+)
+
+// DBPFEntryTGI is combines three identifiers: the Type, Group, and Instance.
+// Together, these identifiers uniquely identify a resource as well as indicating
+// the type of the resource.
+type DBPFEntryTGI struct {
+  // The TypeId indicates the broad type of the resource.
+  TypeId uint32
+
+  // The GroupId indicates the sub-type (or category) of the resource, within
+  // the declared type.
+  GroupId uint32
+
+  // The InstanceId uniquely identifies the resource among all others with the
+  // same TypeId and GroupId.
+  InstanceId uint32
+}
+
+// String returns a string representation of the receiver DBPFEntryTGI.
+func (tgi *DBPFEntryTGI) String() string {
+  return fmt.Sprintf("T: 0x%08X, G: 0x%08X, I: 0x%08X", tgi.TypeId, tgi.GroupId, tgi.InstanceId)
+}
+
+// Equals tests the provided DBPFEntryTGI instance against the receiver to see
+// if they match.
+func (tgi *DBPFEntryTGI) Equals(other *DBPFEntryTGI) bool {
+  if other != nil {
+    result := tgi.TypeId == other.TypeId && tgi.GroupId == other.GroupId && tgi.InstanceId == other.InstanceId
+    return result
+  } else {
+    return false
+  }
+}
+
+// Bytes encodes the receiver as 4 consecutive unsigned 32-bit integers into the
+// provided byte slice.
+func (tgi *DBPFEntryTGI) Bytes(bytes []byte) {
+  copy(bytes[0:4], util.WriteUint32(tgi.TypeId))
+  copy(bytes[4:8], util.WriteUint32(tgi.GroupId))
+  copy(bytes[8:12], util.WriteUint32(tgi.InstanceId))
+}

--- a/entry/dbpfentrytgi_test.go
+++ b/entry/dbpfentrytgi_test.go
@@ -1,0 +1,54 @@
+package entry
+
+import (
+  "testing"
+)
+
+func TestDBPFEntryTGIString(t *testing.T) {
+  tgi := &DBPFEntryTGI{TypeId: 0x12345678, GroupId: 0x9abcdef0, InstanceId: 0x13579bdf}
+
+  expected := "T: 0x12345678, G: 0x9ABCDEF0, I: 0x13579BDF"
+  actual := tgi.String()
+
+  if expected != actual {
+    t.Error()
+  }
+}
+
+func TestZeroDBPFEntryTGIString(t *testing.T) {
+  tgi := new(DBPFEntryTGI)
+
+  expected := "T: 0x00000000, G: 0x00000000, I: 0x00000000"
+  actual := tgi.String()
+
+  if expected != actual {
+    t.Error()
+  }
+}
+
+func TestDBPFEntryTGIEquals(t *testing.T) {
+  tgi := &DBPFEntryTGI{TypeId: 0x12345678, GroupId: 0x9abcdef0, InstanceId: 0x13579bdf}
+  same := tgi
+  equivalent := &DBPFEntryTGI{TypeId: 0x12345678, GroupId: 0x9abcdef0, InstanceId: 0x13579bdf}
+  different := &DBPFEntryTGI{TypeId: 0x01234567, GroupId: 0x89abcdef, InstanceId: 0x02468ace}
+
+  if !tgi.Equals(tgi) {
+    t.Error()
+  }
+
+  if !tgi.Equals(same) {
+    t.Error()
+  }
+
+  if !tgi.Equals(equivalent) {
+    t.Error()
+  }
+
+  if tgi.Equals(different) {
+    t.Error()
+  }
+
+  if tgi.Equals(nil) {
+    t.Error()
+  }
+}

--- a/qfs/qfs.go
+++ b/qfs/qfs.go
@@ -1,0 +1,410 @@
+package qfs
+
+import (
+  "io"
+  "encoding/binary"
+  "fmt"
+)
+
+// Encode takes the bytes contained in the provided byte slice, encodes them, and
+// writes them to the Writer.
+func Encode(w io.Writer, data []byte) error {
+  offsetToLastOccurence := make([]int, 256)
+  for i, _ := range offsetToLastOccurence { offsetToLastOccurence[i] = -1 }
+
+  nextWritePos := 0 // The index of the next byte from data to be written to w
+
+  if e := binary.Write(w, binary.LittleEndian, uint16(0xFB10)); e != nil {
+    return e
+  }
+
+  size := []byte { byte(len(data) >> 16 & 0xFF), byte(len(data) >> 8 & 0xFF), byte(len(data) & 0xFF) }
+  if _, e := w.Write(size); e != nil {
+    return e
+  }
+
+  fmt.Printf("Entering Main processing loop with data: %v\n", data)
+  for i := 0; i < len(data); i++ {
+    v := data[i]
+    fmt.Printf("Main processing loop (i: %d, v: %2x); offsetToLastOccurence[%2x] = %d\n", i, v, v, offsetToLastOccurence[v])
+    if -1 != offsetToLastOccurence[v] {
+      repeatCount := firstByteRepeatCount(data[i:])
+      if compressed, e := writeCompressible(w, data[nextWritePos:i], repeatCount, uint32(i - offsetToLastOccurence[v])); e != nil {
+        return e
+      } else if compressed {
+        nextWritePos = i + int(repeatCount)
+        i += int(repeatCount) - 1
+        fmt.Printf("  Main processing loop: setting i to %d\n", i)
+      } else {
+        fmt.Printf("Updating 1 offsetToLastOccurence[%2x] from %d to %d\n", v, offsetToLastOccurence[v], i)
+        offsetToLastOccurence[v] = i
+      }
+    } else {
+      fmt.Printf("Updating 2 offsetToLastOccurence[%2x] from %d to %d\n", v, offsetToLastOccurence[v], i)
+      offsetToLastOccurence[v] = i
+    }
+  }
+
+  // Need to write the remaining non-repeating bytes
+  if e := writeFinalBlocks(w, data[nextWritePos:]); e != nil {
+    return e
+  }
+
+  return nil
+}
+
+// firstByteRepeatCount counts how many times the first byte of the provided
+// slice is repeated consecutively.
+func firstByteRepeatCount(s []byte) uint32 {
+  i := 1
+  for ; i < len(s) && s[0] == s[i]; i++ {}
+
+  return uint32(i)
+}
+
+// writeCompressible determines if the provided inputs data can be compressed. If
+// it can, it encodes the data and writes it to the Writer; otherwise it does
+// nothing.  writeCompressible returns the number of bytes written.
+func writeCompressible(w io.Writer, data []byte, copyCount, copyOffset uint32) (bool, error) {
+  fmt.Printf("writeCompressible: data=%v, copyCount=%d, copyOffset=%d\n", data, copyCount, copyOffset)
+
+  var control []byte = nil
+  compressed := false
+
+  if copyCount >= 3 && copyCount <= 10 && copyOffset <= 1024 {
+    // 3 to 10 repeating bytes and copyOffset no greater than 1024: can be compressed
+    // with 2 control bytes
+    control = createTwoControlByteBlock(uint32(len(data)), copyCount, copyOffset)
+  } else if copyCount >= 4 && copyCount <= 67 && copyOffset <= 16384 {
+    // 4 to 67 repeating bytes and copyOffset no greater than 16384: can be compressed
+    // with 3 control bytes
+    control = createThreeControlByteBlock(uint32(len(data)), copyCount, copyOffset)
+  } else if copyCount >= 5 && copyCount <= 1028 && copyOffset <= 131072 {
+    // 5 to 1028 repeating bytes and copyOffset no greater than 131072: can be compressed
+    // with 4 control bytes
+    control = createFourControlByteBlock(uint32(len(data)), copyCount, copyOffset)
+  }
+
+  if control != nil {
+    // If the data can be compressed, encode it and write it to the Writer
+    consumedBytes, e := writeNonRepeatingBlocks(data, w)
+    if e != nil {
+      return false, e
+    }
+
+    if e := writeCompressedBlock(control, data[consumedBytes:], w); e != nil {
+      return false, e
+    }
+
+    compressed = true
+  }
+
+  return compressed, nil
+}
+
+// writeFinalBlocks encodes and writes all remaining bytes including the final
+// terminating block.
+func writeFinalBlocks(w io.Writer, data []byte) error {
+  fmt.Printf("writeFinalBlocks: data = %v\n", data)
+
+  if consumedBytes, e := writeNonRepeatingBlocks(data, w); e != nil {
+    return e
+  } else {
+    data = data[consumedBytes:]
+  }
+
+  if e := writeCompressedBlock(createFinalControlByteBlock(uint32(len(data)), 0, 0), data, w); e != nil {
+    return e
+  }
+
+  return nil
+}
+
+// writeNonRepeatingBlocks encodes and writes blocks of bytes that do not include
+// any copied bytes from earlier in the stream.
+func writeNonRepeatingBlocks(data []byte, w io.Writer) (consumedBytes int, e error) {
+  // Blocks of non-repeating bytes are limited to 4 to 112 bytes in length (in
+  // increments of 4).  Write as many full blocks of 112 as possible first, then
+  // write the remaining bytes.
+  fmt.Printf("writeNonRepeatingBlocks: data=%v\n", data)
+
+  for len(data) >= 112 {
+    if e := writeCompressedBlock(createOneControlByteBlock(112, 0, 0), data[0:112], w); e != nil {
+      return consumedBytes, e
+    }
+
+    data = data[112:]
+    consumedBytes += 112
+  }
+
+  blockSize := int(len(data) / 4) * 4
+  if blockSize > 0 {
+    if e := writeCompressedBlock(createOneControlByteBlock(uint32(blockSize), 0, 0), data[consumedBytes:consumedBytes + blockSize], w); e != nil {
+      return consumedBytes, e
+    }
+
+    consumedBytes += blockSize
+  }
+
+  return consumedBytes, nil
+}
+
+// createOneControlByteBlock creates a slice of 1 byte that incorporates the
+// dataLen (p) into this bit pattern:
+//  byte0: 111ppppp
+// This function ignores the copyCount and copyOffset.
+func createOneControlByteBlock(dataLen, copyCount, copyOffset uint32) []byte {
+  fmt.Printf("Creating 1-control byte: %d, %d, %d\n", dataLen, copyCount, copyOffset)
+
+  control := make([]byte, 1)
+
+  control[0] = byte(0xE0 | dataLen / 4 - 1)
+
+  return control
+}
+
+// createTwoControlByteBlock creates a slice of 2 bytes that incorporates the
+// dataLen (p), copyCount (c), and copyOffset(o) into this bit pattern:
+//  byte0: 0oocccpp
+//  byte1: oooooooo
+func createTwoControlByteBlock(dataLen, copyCount, copyOffset uint32) []byte {
+  fmt.Printf("Creating 2-control byte: %d, %d, %d\n", dataLen, copyCount, copyOffset)
+
+  copyOffset -= 1
+  copyCount -= 3
+
+  control := make([]byte, 2)
+
+  control[0] = byte(copyOffset >> 8 & 0x3 << 5 | copyCount & 0x7 << 2 | dataLen & 0x3)
+  control[1] = byte(copyOffset & 0xFF)
+
+  return control
+}
+
+// createThreeControlByteBlock creates a slice of 3 bytes that incorporates the
+// dataLen (p), copyCount (c), and copyOffset (o) into this bit pattern:
+//  byte0: 10cccccc
+//  byte1: ppoooooo
+//  byte2: oooooooo
+func createThreeControlByteBlock(dataLen, copyCount, copyOffset uint32) []byte {
+  fmt.Printf("Creating 3-control byte: %d, %d, %d\n", dataLen, copyCount, copyOffset)
+
+  copyOffset -= 1
+  copyCount -= 4
+
+  control := make([]byte, 3)
+
+  control[0] = byte(0x80 | copyCount & 0x3F)
+  control[1] = byte(dataLen & 0x3 << 6 | copyOffset >> 8 & 0x3F)
+  control[2] = byte(copyOffset & 0xFF)
+
+  return control
+}
+
+// createFourControlByteBlock creates a slice of 4 bytes that incorporates the
+// dataLen (p), copyCount (c), and copyOffset (o) into this bit pattern:
+//  byte0: 110occpp
+//  byte1: oooooooo
+//  byte2: oooooooo
+//  byte3: cccccccc
+func createFourControlByteBlock(dataLen, copyCount, copyOffset uint32) []byte {
+  fmt.Printf("Creating 4-control byte: %d, %d, %d\n", dataLen, copyCount, copyOffset)
+
+  copyOffset -= 1
+  copyCount -= 5
+
+  control := make([]byte, 4)
+
+  control[0] = byte(0xC0 | copyOffset >> 16 & 0x1 << 4 | copyCount >> 8 & 0x3 << 2 | dataLen & 0x3)
+  control[1] = byte(copyOffset >> 8 & 0xFF)
+  control[2] = byte(copyOffset & 0xFF)
+  control[3] = byte(copyCount & 0xFF)
+
+  return control
+}
+
+// createFinalControlByteBlock creates a slice of 1 byte that incorporates the
+// dataLen (p) into this bit pattern:
+//  byte0: 111111pp
+// This function ignores the copyCount and copyOffset.  This block also serves
+// as the terminating block for the compressed data stream.
+func createFinalControlByteBlock(dataLen, copyCount, copyOffset uint32) []byte {
+  control := make([]byte, 1)
+
+  control[0] = byte(0xFC | dataLen & 0x3)
+
+  return control
+}
+
+// writeCompressedBlock writes the provided control bytes and the proceeding
+// bytes passed in as the control and data slices to the io.Writer passed in.
+// The number of bytes written, including the control bytes is returned.
+func writeCompressedBlock(control, data []byte, w io.Writer) error {
+  fmt.Printf("writeCompressedBlock: data=%v\n", data)
+
+  buffer := make([]byte, len(control) + len(data))
+
+  copy(buffer, control)
+  copy(buffer[len(control):], data)
+
+  if _, e := w.Write(buffer); e != nil {
+    return e
+  }
+
+  return nil
+}
+
+// Decode reads bytes from the provided Reader and decodes them.  The decoded
+// bytes are returned in a byte slice.
+func Decode(r io.Reader) ([]byte, error) {
+  // The buffer is 113 bytes long because the largest byte sequence from a single
+  // control code is a 1-byte control byte with 112 proceeding bytes.
+  buffer := make([]byte, 113)
+
+  // Consume the compression header
+  if _, e := r.Read(buffer[0:2]); e != nil {
+    return nil, e
+  }
+
+  // Read the uncompressed data size
+  if _, e := r.Read(buffer[0:3]); e != nil {
+    return nil, e
+  }
+  size := uint32(buffer[0] << 16 | buffer[1] << 8 | buffer[2])
+  fmt.Printf("Decode determined uncompressed size: %d\n", size)
+
+  // Create the output byte slice
+  output := make([]byte, size)
+  outputPos := 0
+
+  for {
+    if n, e := r.Read(buffer[0:1]); n == 0 && e != nil {
+      break;
+    }
+
+    if e := decodeSequence(buffer[0], r, output, &outputPos); e != nil {
+      return nil, e
+    }
+  }
+
+  return output, nil
+}
+
+// decodeSequence decodes a sequence of bytes and writes the decoded bytes in
+// the provided byte slice.
+func decodeSequence(control byte, r io.Reader, output []byte, outputPos *int) error {
+  fmt.Printf("decodeSequence: control=0x%02X, outputPos=%d\n", control, *outputPos)
+
+  buffer := make([]byte, 4)
+  buffer[0] = control
+
+  var f func([]byte) (int, int, int)
+
+  switch {
+  case control & 0x80 == 0x0:
+    // 2-byte control code
+    fmt.Printf("  decodeSequence: control & 0x80 = 0x%2X (0x00 ?)\n", control & 0xFC)
+    if _, e := r.Read(buffer[1:2]); e != nil {
+      return e
+    }
+    f = decodeTwoByteSequence
+    break
+  case control & 0xC0 == 0x80:
+    // 3-byte control code
+    fmt.Printf("  decodeSequence: control & 0xC0 = 0x%2X (0x80 ?)\n", control & 0xFC)
+    if _, e := r.Read(buffer[1:3]); e != nil {
+      return e
+    }
+    f = decodeThreeByteSequence
+    break
+  case control & 0xE0 == 0xC0:
+    // 4-byte control code
+    fmt.Printf("  decodeSequence: control & 0xC0 = 0x%2X (0xC0)\n", control & 0xC0)
+    if _, e := r.Read(buffer[1:4]); e != nil {
+      return e
+    }
+    f = decodeFourByteSequence
+    break
+  case control & 0xE4 == 0xE0:
+    // 1-byte control code
+    fmt.Printf("  decodeSequence: control & 0xE4 = 0x%2X (0xE0)\n", control & 0xFC)
+    f = decodeOneByteSequence
+    break
+  case control & 0xFC == 0xFC:
+    // Special 1-byte control code (terminator)
+    fmt.Printf("  decodeSequence: control & 0xFC = 0x%2X (0xFC)\n", control & 0xFC)
+    f = decodeFinalSequence
+    break
+  }
+
+  proceeding, count, offset := f(buffer)
+  pos := *outputPos
+  if n, e := r.Read(output[pos:pos + proceeding]); e != nil {
+    return e
+  } else {
+    *outputPos += n
+  }
+  if 0 < offset {
+    b := output[*outputPos - offset]
+    for i := 0; i < count; i++ {
+      output[*outputPos + i] = b
+    }
+
+    *outputPos += count
+  }
+
+  return nil
+}
+
+// decodeFourByteSequence decodes a 4-byte control sequence to extract the number
+// of proceeding bytes, the number of times to write the repeating byte, and the
+// offset of the repeating byte.
+func decodeFourByteSequence(control []byte) (proceeding, count, offset int) {
+  proceeding = int(control[0] & 0x3)
+  count = int(control[0] & 0xC << 6 + control[3] + 5)
+  offset = int(control[0] & 0x10 << 12 + control[1] << 8 + control[2] + 1)
+
+  return
+}
+
+// decodeThreeByteSequence decodes a 3-byte control sequence to extract the number
+// of procceeding bytes, the number of times to write the repeating byte, and the
+// offset of the repeating byte.
+func decodeThreeByteSequence(control []byte) (proceeding, count, offset int) {
+  proceeding = int(control[1] & 0xC0 >> 6 & 0x3)
+  count = int(control[0] & 0x3F + 4)
+  offset = int(control[1] & 0x3F << 8 + control[2] + 1)
+
+  return
+}
+
+// decodeTwoByteSequence decodes a 2-byte control sequence to extract the number
+// of procceeding bytes, the number of times to write the repeating byte, and the
+// offset of the repeating byte.
+func decodeTwoByteSequence(control []byte) (proceeding, count, offset int) {
+  proceeding = int(control[0] & 0x3)
+  count = int(control[0] & 0x1C >> 2 + 3)
+  offset = int(control[0] & 0x60 << 3 + control[1] + 1)
+
+  return
+}
+
+// decodeOneByteSequence decodes a 1-byte control sequence to extract the number
+// of procceeding bytes.  The repeating count and offset is simply set to zero.
+func decodeOneByteSequence(control []byte) (proceeding, count, offset int) {
+  proceeding = int(control[0] & 0x1F << 2 + 4)
+  count = 0
+  offset = 0
+
+  return
+}
+
+// decodeFinalSequence decodes a 1-byte control sequence to extract the number
+// of proceeding bytes.  The repeating count and offset is simply set to zero.
+func decodeFinalSequence(control []byte) (proceeding, count, offset int) {
+  proceeding = int(control[0] & 0x3)
+  count = 0
+  offset = 0
+
+  return
+}

--- a/qfs/qfs_test.go
+++ b/qfs/qfs_test.go
@@ -1,0 +1,122 @@
+package qfs
+
+import (
+  "testing"
+  "bytes"
+)
+
+func TestEncodeWithZeroBytes(t *testing.T) {
+  buffer := new(bytes.Buffer)
+  data := make([]byte, 0)
+
+  if e := Encode(buffer, data); e != nil {
+    t.Error()
+  }
+
+  expected := []byte{ 0x10, 0xFB, 0x0, 0x0, 0x0, 0xFC }
+
+  CheckIfSlicesAreEqual(t, buffer.Bytes(), expected)
+}
+
+func TestEncodeWithSingleByte(t *testing.T) {
+  buffer := new(bytes.Buffer)
+  data := []byte{ 0xA5 }
+
+  if e := Encode(buffer, data); e != nil {
+    t.Error()
+  }
+
+  expected := []byte{ 0x10, 0xFB, 0x0, 0x0, 0x1, 0xFD, 0xA5 }
+
+  CheckIfSlicesAreEqual(t, buffer.Bytes(), expected)
+}
+
+func TestEncodeWithA3ByteChain(t *testing.T) {
+  buffer := new(bytes.Buffer)
+  data := []byte{ 0xA5, 0x24, 0xA5, 0xA5, 0xA5 }
+
+  if e := Encode(buffer, data); e != nil {
+    t.Error()
+  }
+
+  expected := []byte{ 0x10, 0xFB, 0x0, 0x0, 0x5, 0x2, 0x1, 0xA5, 0x24, 0xFC }
+
+  CheckIfSlicesAreEqual(t, buffer.Bytes(), expected)
+}
+
+func TestEncodeWithMultipleRepeatingChains(t *testing.T) {
+  buffer := new(bytes.Buffer)
+  data := []byte{ 0xA5, 0x24, 0x5C, 0x71, 0xA5, 0xA5, 0xA5, 0x2E, 0x6A, 0x71, 0x71, 0x71, 0x71, 0x88, 0x04 }
+
+  if e := Encode(buffer, data); e != nil {
+    t.Error()
+  }
+
+  expected := []byte{ 0x10, 0xFB, 0x0, 0x0, 0xF, 0xE0, 0xA5, 0x24, 0x5C, 0x71, 0x0, 0x3, 0x6, 0x5, 0x2E, 0x6A, 0xFE, 0x88, 0x04 }
+
+  CheckIfSlicesAreEqual(t, buffer.Bytes(), expected)
+}
+
+func TestDecodeZeroBytes(t *testing.T) {
+  buffer := bytes.NewBuffer([]byte{ 0x10, 0xFB, 0x0, 0x0, 0x0, 0xFC })
+
+  data, e := Decode(buffer)
+  if e != nil {
+    t.Error()
+  }
+
+  expected := make([]byte, 0)
+
+  CheckIfSlicesAreEqual(t, data, expected)
+}
+
+func TestDecodeSingleByte(t *testing.T) {
+  buffer := bytes.NewBuffer([]byte{ 0x10, 0xFB, 0x0, 0x0, 0x1, 0xFD, 0x47 })
+
+  data, e := Decode(buffer)
+  if e != nil {
+    t.Error()
+  }
+
+  expected := []byte{ 0x47 }
+
+  CheckIfSlicesAreEqual(t, data, expected)
+}
+
+func TestDecodeSingle3ByteChain(t *testing.T) {
+  buffer := bytes.NewBuffer([]byte{ 0x10, 0xFB, 0x0, 0x0, 0x7, 0x03, 0x02, 0x47, 0x69, 0x22, 0xFD, 0x3D })
+
+  data, e := Decode(buffer)
+  if e != nil {
+    t.Error()
+  }
+
+  expected := []byte{ 0x47, 0x69, 0x22, 0x47, 0x47, 0x47, 0x3D }
+
+  CheckIfSlicesAreEqual(t, data, expected)
+}
+
+func TestDecodeMultipleByteChains(t *testing.T) {
+  buffer := bytes.NewBuffer([]byte{ 0x10, 0xFB, 0x0, 0x0, 0xF, 0xE0, 0xA5, 0x24, 0x5C, 0x71, 0x0, 0x3, 0x6, 0x5, 0x2E, 0x6A, 0xFE, 0x88, 0x04 })
+
+  data, e := Decode(buffer)
+  if e != nil {
+    t.Error()
+  }
+
+  expected := []byte{ 0xA5, 0x24, 0x5C, 0x71, 0xA5, 0xA5, 0xA5, 0x2E, 0x6A, 0x71, 0x71, 0x71, 0x71, 0x88, 0x04 }
+
+  CheckIfSlicesAreEqual(t, data, expected)
+}
+
+func CheckIfSlicesAreEqual(t *testing.T, actual []byte, expected []byte) {
+  if len(actual) != len(expected) {
+    t.Errorf("Actual slice size %d didn't match expected size %d", len(actual), len(expected))
+  }
+
+  for i, v := range actual {
+    if v != expected[i] {
+      t.Errorf("Byte %d: expected %2x, but actually was %2x", i, expected[i], v)
+    }
+  }
+}

--- a/util/binary.go
+++ b/util/binary.go
@@ -1,0 +1,22 @@
+package util
+
+// ReadUint32 reads up to 4 bytes in little endian order and constructs an
+// unsigned 32-bit integer value.
+func ReadUint32(bytes []byte) (result uint32) {
+  for i := 0; i < 4 && i < len(bytes); i++ {
+    result |= uint32(bytes[i]) << uint32(8 * i)
+  }
+
+  return result
+}
+
+// WriteUint32 writes am unsigned 32-bit integer value into a byte slice.
+func WriteUint32(value uint32) (result []byte) {
+  result = make([]byte, 4)
+
+  for i := 0; i < 4; i++ {
+    result[i] = byte(value >> uint32(8 * i) & 0xFF)
+  }
+
+  return result
+}

--- a/util/binary_test.go
+++ b/util/binary_test.go
@@ -1,0 +1,83 @@
+package util
+
+import (
+  "testing"
+)
+
+func TestReadUint32FourByteSlice(t *testing.T) {
+  data := []byte{ 0x28, 0x34, 0x71, 0xCA }
+
+  expected := uint32(3396416552)
+  actual := ReadUint32(data)
+
+  if actual != expected {
+    t.Error()
+  }
+}
+
+func TestReadUint32ThreeByteSlice(t *testing.T) {
+  data := []byte{ 0x28, 0x34, 0x71 }
+
+  expected := uint32(7418920)
+  actual := ReadUint32(data)
+
+  if actual != expected {
+    t.Error()
+  }
+}
+
+func TestReadUint32ZeroByteSlice(t *testing.T) {
+  data := []byte{}
+
+  expected := uint32(0)
+  actual := ReadUint32(data)
+
+  if actual != expected {
+    t.Error()
+  }
+}
+
+func TestReadUint32SixByteSlice(t *testing.T) {
+  data := []byte{ 0x28, 0x34, 0x71, 0xCA, 0xFB, 0x19 }
+
+  expected := uint32(3396416552)
+  actual := ReadUint32(data)
+
+  if actual != expected {
+    t.Error()
+  }
+}
+
+func TestWriteZero(t *testing.T) {
+  value := uint32(0)
+
+  expected := []byte{ 0x00, 0x00, 0x00, 0x00 }
+  actual := WriteUint32(value)
+
+  if len(actual) != len(expected) {
+    t.Error()
+  }
+
+  for i := 0; i < len(expected); i++ {
+    if actual[i] != expected[i] {
+      t.Error()
+    }
+  }
+}
+
+func TestWriteValue(t *testing.T) {
+  value := uint32(3396416552)
+
+  expected := []byte{ 0x28, 0x34, 0x71, 0xCA }
+  actual := WriteUint32(value)
+
+  if len(actual) != len(expected) {
+    t.Error()
+  }
+
+  for i := 0; i < len(expected); i++ {
+    if actual[i] != expected[i] {
+      t.Error()
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces the qfs.go module which provides the ability to Encode (compress) binary data from a byte slice to an io.Writer, as well as Decoding (decompress) binary data from an io.Reader into a byte slice.

It also expands the DBPF struct to introduce functions to Load and Save instances.  It also permits adding new DBPFEntry instances so that they can be saved.
